### PR TITLE
Update resolvconf during installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,10 @@
     restart_policy: always
     command: -domain={{ domain }}
 
+- name: update resolvconf
+  become: yes
+  command: resolvconf -u
+
 - name: test resolution
   shell: getent hosts dnsdock.docker
   changed_when: false


### PR DESCRIPTION
It seems updating resolvconf is required (at least on Ubuntu 16.04) is
required before the test runs.
